### PR TITLE
Revert binder ref

### DIFF
--- a/binder-gallery.yaml
+++ b/binder-gallery.yaml
@@ -7,5 +7,5 @@ description: >-
 gallery_repository: pangeo-gallery/pangeo-gallery
 binder_url: "https://binder.pangeo.io"
 binder_repo: pangeo-gallery/default-binder
-binder_ref: 7b84eb4
+binder_ref: 80584d2
 binderbot_target_branch: binderbot-built

--- a/binder-gallery.yaml
+++ b/binder-gallery.yaml
@@ -7,5 +7,5 @@ description: >-
 gallery_repository: pangeo-gallery/pangeo-gallery
 binder_url: "https://binder.pangeo.io"
 binder_repo: pangeo-gallery/default-binder
-binder_ref: 53de928
+binder_ref: 7b84eb4
 binderbot_target_branch: binderbot-built


### PR DESCRIPTION
I'd like to temporarily revert to this earlier binder ref. The reason is a holoviews / hvplot bug that I uncovered today (https://github.com/holoviz/hvplot/issues/543). I need my SSH demo notebook to work.